### PR TITLE
improve delete operation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,9 @@ require (
 )
 
 require (
+	github.com/Jeffail/gabs/v2 v2.7.0 // indirect
+	github.com/akshaybharambe14/ijson v0.1.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
+	github.com/valyala/fastjson v1.6.4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/Jeffail/gabs/v2 v2.7.0 h1:Y2edYaTcE8ZpRsR2AtmPu5xQdFDIthFG0jYhu5PY8kg=
+github.com/Jeffail/gabs/v2 v2.7.0/go.mod h1:dp5ocw1FvBBQYssgHsG7I1WYsiLRtkUaB1FEtSwvNUw=
+github.com/akshaybharambe14/ijson v0.1.0 h1:Up4WTp0cgb0qy6Dwqqz/eX7QsJlVo0l2QYPMVRnXKWk=
+github.com/akshaybharambe14/ijson v0.1.0/go.mod h1:i55ERlIvPizxAx284x9/tgl97aiZru9lBkq56TozSWA=
 github.com/tidwall/gjson v1.14.2 h1:6BBkirS0rAHjumnjHF6qgy5d2YAJ1TLIaFE2lzfOLqo=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
@@ -6,3 +10,5 @@ github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
 github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
+github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXVQ=
+github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=


### PR DESCRIPTION
This pull request adds benchmarking support for three additional JSON libraries (`gabs`, `ijson`, and `fastjson`) to the test suite, and introduces new ultra-fast deletion logic for nested JSON paths in `njson`. The changes improve both the breadth of performance comparisons and the efficiency of certain delete operations. The most important changes are grouped below:

**Benchmarking Enhancements:**

* Added benchmarks for `gabs`, `ijson`, and `fastjson` libraries for various JSON access patterns (simple, complex, multipath, filter, and set operations) in `benchmark/bench_test.go`, enabling direct performance comparison with existing libraries. [[1]](diffhunk://#diff-426a906dffbb9bf248c49167f51e1a9c68c8fc3ef891dd9845244b359eee5c87R106-R129) [[2]](diffhunk://#diff-426a906dffbb9bf248c49167f51e1a9c68c8fc3ef891dd9845244b359eee5c87R149-R190) [[3]](diffhunk://#diff-426a906dffbb9bf248c49167f51e1a9c68c8fc3ef891dd9845244b359eee5c87R208-R246) [[4]](diffhunk://#diff-426a906dffbb9bf248c49167f51e1a9c68c8fc3ef891dd9845244b359eee5c87R295-R335) [[5]](diffhunk://#diff-426a906dffbb9bf248c49167f51e1a9c68c8fc3ef891dd9845244b359eee5c87R351-R402) [[6]](diffhunk://#diff-426a906dffbb9bf248c49167f51e1a9c68c8fc3ef891dd9845244b359eee5c87R437-R445) [[7]](diffhunk://#diff-426a906dffbb9bf248c49167f51e1a9c68c8fc3ef891dd9845244b359eee5c87R461-R469)
* Updated test data initialization to parse JSON objects for use with `ijson` benchmarks, ensuring proper input types for all tested libraries. [[1]](diffhunk://#diff-426a906dffbb9bf248c49167f51e1a9c68c8fc3ef891dd9845244b359eee5c87R5-R20) [[2]](diffhunk://#diff-426a906dffbb9bf248c49167f51e1a9c68c8fc3ef891dd9845244b359eee5c87R39-R49) [[3]](diffhunk://#diff-426a906dffbb9bf248c49167f51e1a9c68c8fc3ef891dd9845244b359eee5c87R66-R68)
* Added new dependencies for the benchmarked libraries in `go.mod`.

**Performance Improvements in Deletion Logic:**

* Implemented an optimized fast path for nested key deletion (`deleteFastPath` and improved `deleteFastSimpleKey`) in `njson_set.go`, enabling direct byte-level manipulation for compact JSON and avoiding full parsing when possible.
* Updated `DeleteWithOptions` to use the new fast deletion logic when applicable, falling back to the standard setter only if fast deletion is not possible.

**Minor Fixes:**

* Fixed realistic benchmark update logic to discard unused return values from setter functions, ensuring correct usage and avoiding unnecessary assignments. [[1]](diffhunk://#diff-426a906dffbb9bf248c49167f51e1a9c68c8fc3ef891dd9845244b359eee5c87L401-R630) [[2]](diffhunk://#diff-426a906dffbb9bf248c49167f51e1a9c68c8fc3ef891dd9845244b359eee5c87L424-R653)